### PR TITLE
Use image_data() to consistently get 4 channel bitmap array, fixes #20

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Imports:
     tibble,
     Rcpp,
     RcppParallel,
-    magick,
+    magick (>= 1.6),
     purrr,
     magrittr,
     dplyr,

--- a/R/histogram.R
+++ b/R/histogram.R
@@ -34,11 +34,12 @@
 #'
 #' @importFrom tibble as_tibble
 #' @importFrom dplyr mutate
+#' @importFrom magick image_data
 #' @importFrom magrittr %>%
 #'
 #' @export
 image_histogram_data <- function(im){
-  bitmap <- im[[1]]
+  bitmap <- image_data(im, 'rgba')
   as_tibble(magick_image_histogram(bitmap))
 }
 

--- a/R/pixelize.R
+++ b/R/pixelize.R
@@ -1,6 +1,6 @@
 as_bitmap <- function(img){
   if( inherits(img, "magick-image")){
-    img <- img[[1]]
+    img <- image_data(img, 'rgba')
   }
   img
 }


### PR DESCRIPTION
There was a change in magick 1.6 where `img[[1]]` now returns an `n * m * 3` array (instead of 4) if the image does not have an alpha channel. This PR gets you the old behavior which always returns 4 channels.